### PR TITLE
Add dashboard page metadata

### DIFF
--- a/app/dashboard/cycles/[cycleId]/page.tsx
+++ b/app/dashboard/cycles/[cycleId]/page.tsx
@@ -1,4 +1,13 @@
 import { DeploymentBoard } from '@/components/deployment/deployment-board';
+import type { Metadata } from 'next';
+
+export async function generateMetadata({ params }: { params: { cycleId: string } }): Promise<Metadata> {
+  const { cycleId } = params;
+  return {
+    title: `Deployment Board – Cycle ${cycleId} – TimelineCI`,
+    description: 'Monitor deployments and manage dependencies for this cycle.',
+  };
+}
 
 interface CyclePageProps {
   params: Promise<{

--- a/app/dashboard/history/page.tsx
+++ b/app/dashboard/history/page.tsx
@@ -1,4 +1,10 @@
 import { HistoryPage } from '@/components/history/history-page';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Deployment History – TimelineCI',
+  description: 'View a timeline of past deployments and track deployment activities.',
+};
 
 export default function HistoryRoute() {
   return <HistoryPage />;

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,4 +1,10 @@
 import { CyclesPage } from '@/components/cycles/cycles-page';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Deployment Cycles – TimelineCI',
+  description: 'Manage deployment cycles and coordinate releases.',
+};
 
 export default function DashboardPage() {
   return <CyclesPage />;

--- a/app/dashboard/services/page.tsx
+++ b/app/dashboard/services/page.tsx
@@ -1,4 +1,10 @@
 import { ServicesPage } from '@/components/services/services-page';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Services – TimelineCI',
+  description: 'Manage your service pool and assign services to deployment cycles.',
+};
 
 export default function ServicesRoute() {
   return <ServicesPage />;


### PR DESCRIPTION
## Summary
- add `metadata`/`generateMetadata` exports for dashboard pages

## Testing
- `npm run lint` *(fails: oxlint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866dfbe03448321b0029db159527ec1